### PR TITLE
Add missing --git flag in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ but this works:
 
 ```shell
 # espanso uninstall effective-markdown # In case you want to upgrade
-espanso install effective-markdown --external  \
+espanso install effective-markdown --external --git \
     https://github.com/katrinleinweber/espanso-effective-markdown
 ```
 


### PR DESCRIPTION
Just adding the missing `--git` flag in the install instructions in the readme, since espanso wants it.